### PR TITLE
feat: bootstrap v0.0.1 (no gradle wrapper)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: 'gradle'  # active le cache deps Gradle
+
+      - name: Setup Gradle (no wrapper)
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+
+      - name: Ensure no Gradle wrapper committed
+        run: |
+          test ! -e gradlew && test ! -e gradlew.bat && test ! -d gradle || \
+          (echo "Gradle wrapper détecté, interdit à l'étape 1"; exit 1)
+
+      - name: Build
+        run: gradle build --stacktrace --warning-mode all
+
+      - name: Upload plugin jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: HeneriaBedwars-${{ github.sha }}
+          path: build/libs/*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Java/IDE
+/.idea/
+/.project
+/.classpath
+/.settings/
+/*.iml
+/.vscode/
+
+# Build
+/build/
+/out/
+/bin/
+
+# Gradle (no wrapper committed)
+.gradle/
+gradle/
+gradlew
+gradlew.bat
+
+# OS
+.DS_Store
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.0.1] - 2025-08-16
+### Ajouté
+- Build Gradle (Kotlin DSL) sans wrapper.
+- CI GitHub Actions (Java 21 + setup-gradle, artefact).
+- Plugin minimal: commande `/hbw` + tab-complete.
+- Ressources: plugin.yml, config.yml, messages.yml.
+- Docs: README, ROADMAP (Étape 1), CHANGELOG.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Heneria
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# HeneriaBedwars
+# HeneriaBedwars (Spigot 1.21) — Étape 1
+
+Base “prod” du plugin Bedwars maison (Java 21, Spigot 1.21).
+
+## Build local (sans wrapper)
+- Prérequis : Java 21 + Gradle ≥ 8.9 installé.
+- Commande : `gradle build`
+- Jar : `build/libs/HeneriaBedwars-0.0.1.jar`
+
+## Installation
+1) Serveur **Spigot 1.21** (Java 21).
+2) Déposer le JAR dans `plugins/`.
+3) Démarrer, vérifier les logs.
+4) Test : `/hbw version`, `/hbw reload`.
+
+## Commandes
+- `/hbw version` — affiche la version.
+- `/hbw reload` — recharge `config.yml`.
+
+## Permissions
+- `heneria.use` (true par défaut)
+- `heneria.admin` (op)
+
+## Performances (Spigot)
+Mettre `sync-chunk-writes=false` dans `server.properties` (I/O chunks off-thread). *(Recommandation Étape 1)*
+
+## Roadmap
+Voir [ROADMAP.md](./ROADMAP.md).
+
+## Licence
+MIT

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,52 @@
+# HeneriaBedwars — Roadmap (Étape 1)
+
+## Vision (contexte rapide)
+Créer un Bedwars performant et stable, 100% Spigot, sans dépendances dures, avec un socle code propre et testable.
+
+## Étape 1 — Bootstrap & Fondation (cette livraison)
+Objectif : livrer un dépôt exploitable **prod** avec CI et squelette plugin, prêt pour itérations gameplay.
+
+### 1. Build & Toolchain
+- Java 21 (toolchain).
+- Gradle ≥ 8.9 **sans wrapper** (installé localement / provisionné par CI).
+- Dépendance compileOnly : `org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT` (repo snapshots).
+- Tests JUnit5 (base).
+
+### 2. Structure de projet
+```
+
+src/main/java/fr/heneria/bedwars/...
+src/main/resources/
+.github/workflows/ci.yml
+README.md, CHANGELOG.md, ROADMAP.md
+settings.gradle.kts, build.gradle.kts
+
+```
+Conventions : packages `fr.heneria.bedwars.*`, UTF-8, logs simples, zéro allocation au tick.
+
+### 3. Plugin minimal
+- Classe main `HeneriaBedwarsPlugin`.
+- Commande `/hbw <version|reload|help>` + tab-complete.
+- `plugin.yml` (api-version: "1.21"), `config.yml`, `messages.yml`.
+
+### 4. CI GitHub Actions (sans wrapper)
+- `actions/setup-java@v4` (Temurin 21, cache Gradle).
+- `gradle/actions/setup-gradle@v3` (Gradle 8.9).
+- Vérification absence wrapper.
+- Build + upload artefact jar.
+
+### 5. Perf/Sécu/Qualité
+- **Perf** : aucune tâche longue sur main thread; recommandation serveur `sync-chunk-writes=false`.
+- **Sécu** : permissions `heneria.admin` pour `/hbw reload`.
+- **Qualité** : messages externalisés, logs clairs, NPE évités (null-check commandes).
+
+### 6. Livrables Étape 1
+- Code & ressources listés ci-dessus.
+- CI fonctionnelle avec artefact.
+- Docs complètes (README, CHANGELOG, cette ROADMAP).
+
+### 7. Critères d’acceptation Étape 1
+- `gradle build` OK local/CI (Java 21).
+- Plugin charge sur Spigot 1.21 sans erreur (log “activé”).
+- `/hbw version` & `/hbw reload` opérationnels.
+- Aucun fichier wrapper Gradle dans le repo.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    java
+}
+
+group = "fr.heneria"
+version = "0.0.1"
+description = "HeneriaBedwars plugin (Spigot 1.21) — étape 1"
+
+repositories {
+    mavenCentral()
+    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/") // Spigot API snapshots
+    maven("https://oss.sonatype.org/content/repositories/snapshots/")       // transitives
+}
+
+dependencies {
+    compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT")
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+tasks {
+    withType<JavaCompile> {
+        options.release.set(21)
+        options.encoding = "UTF-8"
+    }
+    test {
+        useJUnitPlatform()
+    }
+    processResources {
+        filesMatching("plugin.yml") {
+            // injecte version depuis Gradle
+            expand("version" to project.version)
+        }
+    }
+    jar {
+        archiveBaseName.set("HeneriaBedwars")
+        archiveVersion.set(project.version.toString())
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "HeneriaBedwars"

--- a/src/main/java/fr/heneria/bedwars/HeneriaBedwarsPlugin.java
+++ b/src/main/java/fr/heneria/bedwars/HeneriaBedwarsPlugin.java
@@ -1,0 +1,24 @@
+package fr.heneria.bedwars;
+
+import fr.heneria.bedwars.command.HbwCommand;
+import fr.heneria.bedwars.command.HbwTabCompleter;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class HeneriaBedwarsPlugin extends JavaPlugin {
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        getLogger().info(() -> "HeneriaBedwars v" + getDescription().getVersion() + " activé.");
+        if (getCommand("hbw") != null) {
+            getCommand("hbw").setExecutor(new HbwCommand(this));
+            getCommand("hbw").setTabCompleter(new HbwTabCompleter());
+        } else {
+            getLogger().severe("Commande /hbw non enregistrée (vérifier plugin.yml).");
+        }
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("HeneriaBedwars désactivé.");
+    }
+}

--- a/src/main/java/fr/heneria/bedwars/command/HbwCommand.java
+++ b/src/main/java/fr/heneria/bedwars/command/HbwCommand.java
@@ -1,0 +1,39 @@
+package fr.heneria.bedwars.command;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+
+public class HbwCommand implements CommandExecutor {
+    private final Plugin plugin;
+
+    public HbwCommand(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0 || "version".equalsIgnoreCase(args[0])) {
+            sender.sendMessage(ChatColor.AQUA + "HeneriaBedwars v" + plugin.getDescription().getVersion());
+            return true;
+        }
+        if ("reload".equalsIgnoreCase(args[0])) {
+            if (!sender.hasPermission("heneria.admin")) {
+                sender.sendMessage(ChatColor.RED + "Permission manquante: heneria.admin");
+                return true;
+            }
+            plugin.reloadConfig();
+            sender.sendMessage(ChatColor.GREEN + "Configuration rechargée.");
+            return true;
+        }
+        if ("help".equalsIgnoreCase(args[0])) {
+            sender.sendMessage(ChatColor.YELLOW + "/hbw version" + ChatColor.GRAY + " - Affiche la version");
+            sender.sendMessage(ChatColor.YELLOW + "/hbw reload" + ChatColor.GRAY + " - Recharge la config");
+            return true;
+        }
+        sender.sendMessage(ChatColor.RED + "Sous-commande inconnue. Essayez /hbw help");
+        return true;
+    }
+}

--- a/src/main/java/fr/heneria/bedwars/command/HbwTabCompleter.java
+++ b/src/main/java/fr/heneria/bedwars/command/HbwTabCompleter.java
@@ -1,0 +1,28 @@
+package fr.heneria.bedwars.command;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+public class HbwTabCompleter implements TabCompleter {
+    private static final List<String> SUBS = Arrays.asList("version", "reload", "help");
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args) {
+        if (args.length == 1) {
+            List<String> out = new ArrayList<>();
+            for (String s : SUBS) {
+                if (s.regionMatches(true, 0, args[0], 0, args[0].length())) {
+                    out.add(s);
+                }
+            }
+            Collections.sort(out);
+            return out;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,3 @@
+# HeneriaBedwars - configuration de base (Étape 1)
+debug: false
+locale: "fr_FR"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,5 @@
+prefix: "&b[Heneria]&r "
+errors:
+  no_permission: "&cPermission insuffisante."
+info:
+  reloaded: "&aConfiguration rechargée."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,17 @@
+name: HeneriaBedwars
+main: fr.heneria.bedwars.HeneriaBedwarsPlugin
+version: "${version}"
+api-version: "1.21"
+authors: [ "Heneria" ]
+description: "HeneriaBedwars (Spigot 1.21) - étape 1"
+website: "https://github.com/tomashb/HeneriaBedwars"
+commands:
+  hbw:
+    description: Commande HeneriaBedwars
+    usage: "/hbw <version|reload|help>"
+    permission: "heneria.use"
+permissions:
+  heneria.use:
+    default: true
+  heneria.admin:
+    default: op


### PR DESCRIPTION
## Summary
- add Gradle build scripts using Java 21 and Spigot 1.21 without committing a wrapper
- provide minimal plugin skeleton with /hbw command and tab completion
- wire up GitHub Actions CI for building and publishing the plugin jar

## Testing
- `gradle build --stacktrace --warning-mode all --console=plain` *(fails: Could not resolve org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT (HTTP 403))*

------
https://chatgpt.com/codex/tasks/task_e_68a0caa4b2fc8329bef9e1d40d23588c