### PR TITLE
fix: declare junit platform launcher for gradle 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@
 - Normalisation: `.editorconfig`, `.gitattributes`, `.gitignore`.
 - Docs: README, ROADMAP (Étape 1 verrouillée).
 
+### Corrigé
+- CI: échec `:test` sous **Gradle 9** (« Failed to load JUnit Platform ») → ajout de `testRuntimeOnly("org.junit.platform:junit-platform-launcher")` conformément à la documentation Gradle 9.
+

--- a/README.md
+++ b/README.md
@@ -5,13 +5,20 @@ Plugin BedWars pour **Spigot 1.21** / **Java 21**.
 
 ## Build local (sans wrapper, compile-only)
 1. Installer **Java 21** (JDK).
-2. Installer **Gradle ≥ 8.9** sur le poste.
-3. Lancer:  
+2. Installer **Gradle 9** sur le poste.
+3. Lancer:
    ```bash
    gradle compileJava test
    ```
 
 > ⚠️ Le **CI ne produit pas de JAR** et les tâches `jar/assemble` sont désactivées. Vous ne devez **pas** publier de `.jar` via ce dépôt.
+
+## Tests (Gradle 9)
+Gradle 9 **nécessite** le `junit-platform-launcher` sur le runtime des tests. Déjà déclaré dans `build.gradle.kts` via :
+```kotlin
+testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+```
+Réf. doc Gradle 9 (Testing / JUnit 5). ([docs.gradle.org][1])
 
 ## Commandes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@
 - [x] `.editorconfig`, `.gitattributes`, `.gitignore`
 - [x] README/CHANGELOG/ROADMAP à jour
 - [x] Tests unitaires de base
+- [x] Fix CI Gradle 9 / JUnit Platform Launcher
 
 > Réfs: Java 21 requis 1.21 ; Spigot snapshots 1.21. :contentReference[oaicite:5]{index=5}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,9 +19,13 @@ repositories {
 }
 
 dependencies {
+  // Spigot API 1.21 snapshots
   compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT")
+
+  // Tests: JUnit Jupiter + launcher required with Gradle 9
   testImplementation(platform("org.junit:junit-bom:5.10.2"))
   testImplementation("org.junit.jupiter:junit-jupiter")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.test {
@@ -36,7 +40,7 @@ tasks.assemble {
   enabled = false
 }
 
-// Option: éviter la résolution transitive inutile sur test
+// Option: garder les modules "changing" frais (snapshots)
 configurations.all {
   resolutionStrategy.cacheChangingModulesFor(0, "seconds")
 }


### PR DESCRIPTION
## Summary
- declare junit-platform-launcher in test runtime for Gradle 9
- document Gradle 9 launcher requirement
- note hotfix completion in roadmap

## Testing
- `gradle test --no-daemon` *(fails: Could not resolve org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef45f43c832992aa13d5e78dbbef